### PR TITLE
Add Cocoapods support

### DIFF
--- a/SwiftPasscodeLock.podspec
+++ b/SwiftPasscodeLock.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+s.name = 'SwiftPasscodeLock'
+s.version = '0.1'
+s.license = { :type => "MIT", :file => 'LICENSE.txt' }
+s.summary = 'An iOS passcode lock with Touch ID authentication written in Swift.'
+s.homepage = 'https://github.com/yankodimitrov/SwiftPasscodeLock'
+s.authors = { 'Yanko Dimitrov' => '' }
+s.source = { :git => 'https://github.com/yankodimitrov/SwiftPasscodeLock.git' }
+
+s.ios.deployment_target = '8.0'
+
+s.source_files = 'SwiftPasscodeLock/PasscodeLock/*.{swift}',
+				 'SwiftPasscodeLock/PasscodeLock/*/*.{swift}',
+				 'SwiftPasscodeLock/ViewControllers/PasscodeViewController.swift',
+				 'SwiftPasscodeLock/Views/*.{swift,xib}',
+				 'SwiftPasscodeLock/en.lproj/*'
+
+s.resources = [
+				'SwiftPasscodeLock/Views/PasscodeView.xib',
+				'SwiftPasscodeLock/en.lproj/*'
+			  ]
+
+s.requires_arc = true
+end

--- a/SwiftPasscodeLock/PasscodeLock/GenericPasscodeLock.swift
+++ b/SwiftPasscodeLock/PasscodeLock/GenericPasscodeLock.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-class GenericPasscodeLock: PasscodeLock, PasscodeLockStateFactory {
+public class GenericPasscodeLock: PasscodeLock, PasscodeLockStateFactory {
     
-    var passcode: [String] {
+    public var passcode: [String] {
         return passcodeStack
     }
     
-    var state: PasscodeLockState? {
+    public var state: PasscodeLockState? {
         didSet {
             
             state?.passcodeLock = self
@@ -24,7 +24,7 @@ class GenericPasscodeLock: PasscodeLock, PasscodeLockStateFactory {
         }
     }
     
-    weak var delegate: PasscodeLockDelegate?
+    public weak var delegate: PasscodeLockDelegate?
     private lazy var passcodeStack = [String]()
     private let repository: PasscodeRepository
     private let length: Int
@@ -34,7 +34,7 @@ class GenericPasscodeLock: PasscodeLock, PasscodeLockStateFactory {
     // MARK: - Initializers
     ///////////////////////////////////////////////////////
     
-    init(length: UInt, repository: PasscodeRepository) {
+    public init(length: UInt, repository: PasscodeRepository) {
         
         self.length = Int(length)
         self.repository = repository
@@ -49,7 +49,7 @@ class GenericPasscodeLock: PasscodeLock, PasscodeLockStateFactory {
     // MARK: - PasscodeLock
     ///////////////////////////////////////////////////////
     
-    func enterSign(sign: String) {
+    public func enterSign(sign: String) {
         
         assert(sign != "", "Can't enter an empty passcode sign")
         
@@ -63,7 +63,7 @@ class GenericPasscodeLock: PasscodeLock, PasscodeLockStateFactory {
         }
     }
     
-    func removeSign() {
+    public func removeSign() {
         
         if passcodeStack.count == 0 {
             return
@@ -74,7 +74,7 @@ class GenericPasscodeLock: PasscodeLock, PasscodeLockStateFactory {
         delegate?.passcodeLock(self, removedSignAtIndex: signCounter)
     }
     
-    func resetSigns() {
+    public func resetSigns() {
         
         passcodeStack.removeAll(keepCapacity: true)
         signCounter = 0
@@ -85,27 +85,27 @@ class GenericPasscodeLock: PasscodeLock, PasscodeLockStateFactory {
     // MARK: - PasscodeLockStateFactory
     ///////////////////////////////////////////////////////
     
-    func makeEnterPasscodeState() -> PasscodeLockState {
+    public func makeEnterPasscodeState() -> PasscodeLockState {
         
         return EnterPasscodeState(passcodeRepository: repository)
     }
     
-    func makeSetPasscodeState() -> PasscodeLockState {
+    public func makeSetPasscodeState() -> PasscodeLockState {
         
         return SetPasscodeState()
     }
     
-    func makeConfirmPasscodeState() -> PasscodeLockState {
+    public func makeConfirmPasscodeState() -> PasscodeLockState {
         
         return ConfirmPasscodeState(passcode: passcode, passcodeRepository: repository)
     }
     
-    func makePasscodesMismatchState() -> PasscodeLockState {
+    public func makePasscodesMismatchState() -> PasscodeLockState {
         
         return PasscodesMismatchState()
     }
     
-    func makeChangePasscodeState() -> PasscodeLockState {
+    public func makeChangePasscodeState() -> PasscodeLockState {
         
         return ChangePasscodeState(passcodeRepository: repository)
     }

--- a/SwiftPasscodeLock/PasscodeLock/PasscodeLock.swift
+++ b/SwiftPasscodeLock/PasscodeLock/PasscodeLock.swift
@@ -64,7 +64,7 @@ public protocol PasscodeRepository: class {
 }
 
 /// MARK: - PasscodeLockPresentable
-@objc protocol PasscodeLockPresentable {
+@objc public protocol PasscodeLockPresentable {
     
     var onCorrectPasscode: ( () -> Void )? {set get}
 }

--- a/SwiftPasscodeLock/PasscodeLock/PasscodeLock.swift
+++ b/SwiftPasscodeLock/PasscodeLock/PasscodeLock.swift
@@ -68,3 +68,14 @@ public protocol PasscodeRepository: class {
     
     var onCorrectPasscode: ( () -> Void )? {set get}
 }
+
+// load the correct bundle for Localization string file
+func getLocalizationBundle() -> NSBundle {
+    // check if a Localization string file is overwritten in main bundle
+    if(NSBundle.mainBundle().pathForResource("PasscodeLock", ofType: "strings") != nil) {
+        return NSBundle.mainBundle()
+    }
+    
+    // return our module bundle
+    return NSBundle(forClass: PasscodeLockPresenter.self)
+}

--- a/SwiftPasscodeLock/PasscodeLock/PasscodeLockPresenter.swift
+++ b/SwiftPasscodeLock/PasscodeLock/PasscodeLockPresenter.swift
@@ -21,7 +21,7 @@ public class PasscodeLockPresenter: NSObject {
     // MARK: - Initializers
     ///////////////////////////////////////////////////////
     
-    init(passcodeViewController: UIViewController, repository: PasscodeRepository, splashView: UIView) {
+    public init(passcodeViewController: UIViewController, repository: PasscodeRepository, splashView: UIView) {
         
         assert(passcodeViewController is PasscodeLockPresentable, "Passcode VC should conform to PasscodeLockPresentable")
         

--- a/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/ChangePasscodeState.swift
+++ b/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/ChangePasscodeState.swift
@@ -24,12 +24,14 @@ public class ChangePasscodeState: PasscodeLockState {
         title = NSLocalizedString(
             "PasscodeLockChangeTitle",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         
         description = NSLocalizedString(
             "PasscodeLockChangeDescription",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         

--- a/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/ConfirmPasscodeState.swift
+++ b/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/ConfirmPasscodeState.swift
@@ -28,12 +28,14 @@ public class ConfirmPasscodeState: PasscodeLockState {
         title = NSLocalizedString(
             "PasscodeLockConfirmTitle",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         
         description = NSLocalizedString(
             "PasscodeLockConfirmDescription",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         

--- a/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/EnterPasscodeState.swift
+++ b/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/EnterPasscodeState.swift
@@ -24,12 +24,14 @@ public class EnterPasscodeState: PasscodeLockState {
         title = NSLocalizedString(
             "PasscodeLockEnterTitle",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         
         description = NSLocalizedString(
             "PasscodeLockEnterDescription",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         

--- a/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/PasscodesMismatchState.swift
+++ b/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/PasscodesMismatchState.swift
@@ -20,12 +20,14 @@ public class PasscodesMismatchState: PasscodeLockState {
         title = NSLocalizedString(
             "PasscodeLockSetTitle",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         
         description = NSLocalizedString(
             "PasscodeLockMismatchDescription",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         

--- a/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/SetPasscodeState.swift
+++ b/SwiftPasscodeLock/PasscodeLock/PasscodeLockStates/SetPasscodeState.swift
@@ -20,12 +20,14 @@ public class SetPasscodeState: PasscodeLockState {
         title = NSLocalizedString(
             "PasscodeLockSetTitle",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         
         description = NSLocalizedString(
             "PasscodeLockSetDescription",
             tableName: "PasscodeLock",
+            bundle: getLocalizationBundle(),
             comment: ""
         )
         

--- a/SwiftPasscodeLock/ViewControllers/PasscodeViewController.swift
+++ b/SwiftPasscodeLock/ViewControllers/PasscodeViewController.swift
@@ -124,7 +124,7 @@ public class PasscodeViewController: UIViewController, PasscodeLockPresentable, 
         
         var error: NSError?
         let context = LAContext()
-        let reason = NSLocalizedString("PasscodeLockTouchIDReason", tableName: "PasscodeLock", comment: "")
+        let reason = NSLocalizedString("PasscodeLockTouchIDReason", tableName: "PasscodeLock", bundle: getLocalizationBundle(), comment: "")
         
         if !context.canEvaluatePolicy(.DeviceOwnerAuthenticationWithBiometrics, error: &error) {
             

--- a/SwiftPasscodeLock/ViewControllers/PasscodeViewController.swift
+++ b/SwiftPasscodeLock/ViewControllers/PasscodeViewController.swift
@@ -31,7 +31,14 @@ public class PasscodeViewController: UIViewController, PasscodeLockPresentable, 
         
         passcodeLock = lock
         
-        super.init(nibName: "PasscodeView", bundle: nil)
+        // check if a custom nib exists in main bundle
+        if(NSBundle.mainBundle().pathForResource("PasscodeView", ofType: "nib") != nil) {
+            super.init(nibName: "PasscodeView", bundle: nil)
+        
+        // else use PasscodeView in our bundle
+        } else {
+            super.init(nibName: "PasscodeView", bundle: NSBundle(forClass: PasscodeViewController.self))
+        }
         
         passcodeLock.delegate = self
     }

--- a/SwiftPasscodeLock/ViewControllers/PasscodeViewController.swift
+++ b/SwiftPasscodeLock/ViewControllers/PasscodeViewController.swift
@@ -27,7 +27,7 @@ public class PasscodeViewController: UIViewController, PasscodeLockPresentable, 
     // MARK: - Initializers
     ///////////////////////////////////////////////////////
     
-    init(passcodeLock lock: PasscodeLock) {
+    public init(passcodeLock lock: PasscodeLock) {
         
         passcodeLock = lock
         

--- a/SwiftPasscodeLock/Views/LockSplashView.swift
+++ b/SwiftPasscodeLock/Views/LockSplashView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class LockSplashView: UIView {
+public class LockSplashView: UIView {
     
     private lazy var icon: UIImageView = {
         
@@ -36,7 +36,7 @@ class LockSplashView: UIView {
 		self.init(frame: UIScreen.mainScreen().bounds)
 	}
     
-    required init(coder aDecoder: NSCoder) {
+    public required init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     


### PR DESCRIPTION
Hello @yankodimitrov. Thanks for the great work you've done so far in this lib.

I have added cocoapods support. 
I left your PasscodeKeychainRepository and PasscodeNSUserDefaultsRepository out, as I think that there is no need for someone to load them both in his code and this will be different for each app.

I was thinking that you might want to create a second pod, like SwiftPasscodeLockFull, that will include them. Which I don't really like as an idea.

Also I have added support for overwriting `PasscodeLock.strings` and/or `PasscodeView.xib` in your app. So as dev can easily change things without worrying about broken library updates using cocoapods.

Please check everything in .podspec, like version and license.