### PR TITLE
Fix for YouTube embedded in webview

### DIFF
--- a/PasscodeLock/PasscodeLockPresenter.swift
+++ b/PasscodeLock/PasscodeLockPresenter.swift
@@ -39,7 +39,9 @@ public class PasscodeLockPresenter {
         
         isPasscodePresented = true
         passcodeLockWindow.windowLevel = 2
-        
+        passcodeLockWindow.hidden = false
+        mainWindow?.windowLevel = 1
+                
         let passcodeLockVC = PasscodeLockViewController(state: .EnterPasscode, configuration: passcodeConfiguration)
         
         passcodeLockVC.dismissCompletionCallback = { [weak self] in
@@ -71,6 +73,8 @@ public class PasscodeLockPresenter {
                 self?.passcodeLockWindow.windowLevel = 0
                 self?.passcodeLockWindow.rootViewController = nil
                 self?.passcodeLockWindow.alpha = 1
+                self?.passcodeLockWindow.hidden = true
+                self?.mainWindow?.windowLevel = 0
             }
         )
     }


### PR DESCRIPTION
This fixes an issue when passcodelock is used together with a view that
has a web view embedded with youtube website and the videos only show
blank.