### PR TITLE
#48: Localization improvement

### DIFF
--- a/PasscodeLock/Functions.swift
+++ b/PasscodeLock/Functions.swift
@@ -11,9 +11,9 @@ import Foundation
 func localizedStringFor(key: String, comment: String) -> String {
     
     let name = "PasscodeLock"
-    let bundle = bundleForResource(name, ofType: "strings")
+    let defaultString = NSLocalizedString(key, tableName: name, bundle: NSBundle(forClass: PasscodeLock.self), comment: comment)
     
-    return NSLocalizedString(key, tableName: name, bundle: bundle, comment: comment)
+    return NSLocalizedString(key, value: defaultString, tableName: name, bundle: NSBundle.mainBundle(), comment: comment)
 }
 
 func bundleForResource(name: String, ofType type: String) -> NSBundle {

--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -84,6 +84,9 @@ public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDeleg
         super.viewDidLoad()
         
         updatePasscodeView()
+        
+        cancelButton?.setTitle(localizedStringFor("PasscodeLockCancelButtonTitle", comment: "Cancel Button Title"), forState: .Normal)
+        deleteSignButton?.setTitle(localizedStringFor("PasscodeLockDeleteButtonTitle", comment: "Delete Button Title"), forState: .Normal)
         deleteSignButton?.enabled = false
         
         setupEvents()

--- a/PasscodeLock/en.lproj/PasscodeLock.strings
+++ b/PasscodeLock/en.lproj/PasscodeLock.strings
@@ -26,6 +26,12 @@
 "PasscodeLockMismatchTitle" = "Try again";
 "PasscodeLockMismatchDescription" = "Passcodes didn\'t match.";
 
+/* Cancel Button Title */
+"PasscodeLockCancelButtonTitle" = "Cancel";
+
+/* Delete Button Title */
+"PasscodeLockDeleteButtonTitle" = "Delete";
+
 /* Touch ID Reason */
 "PasscodeLockTouchIDReason" = "Authentication required to proceed";
 


### PR DESCRIPTION
Adds support for localization of Cancel and Delete buttons. Also changed behavior of obtaining localized strings - even if the project has PasscodeLock.strings file, the library will fall back to default string in case of the project doesn't have specified key. This allows to avoid the UI breakage for existing users who have localized their projects, but didn't specify translations for newly introduced keys.